### PR TITLE
fixup! Add new OATFWGUI release startup check, rework version string to be semver compatible

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -28,6 +28,12 @@ jobs:
       run: curl -L "https://www.python.org/ftp/python/3.10.7/python-3.10.7-embed-amd64.zip" -o python-embedded.zip
     - name: Unzip python embedded
       run: unzip python-embedded.zip -d dist/.python_local
+    - name: Weird DLL workaround so that pip can see all default embedded python modules
+      # See https://github.com/python/cpython/issues/100399#issuecomment-1381486117
+      run: |
+        mkdir dist/.python_local/DLLs
+        GLOBIGNORE="dist/.python_local/python3*.dll"
+        mv -v dist/.python_local/*.{dll,pyd} dist/.python_local/DLLs
     - name: Modify python embedded to allow pip to run # See https://stackoverflow.com/questions/42666121/pip-with-embedded-python
       run: rm -v dist/.python_local/python310._pth
     - name: Download get-pip.py

--- a/OATFWGUI/main.py
+++ b/OATFWGUI/main.py
@@ -92,11 +92,22 @@ def check_new_oatfwgui_release() -> Optional[Tuple[str, str]]:
         if latest_release_ver is None or release_ver > latest_release_ver:
             latest_release_ver = release_ver
 
-    if latest_release_ver > local_ver:
-        log.info(f'New version is available! {latest_release_ver} > {local_ver}')
+    if latest_release_ver is None:
+        log.debug(f'No latest release? {response.json()}')
+        return None
+
+    # need to 'finalize' the version, as we use the prerelease/build fields to indicate a release version
+    # i.e. 0.0.12 > 0.0.12-release+4702dd
+    latest_release_ver_finialized = latest_release_ver.finalize_version()
+    local_ver_finialized = local_ver.finalize_version()
+
+    if latest_release_ver_finialized > local_ver_finialized:
+        log.info(f'New version is available! '
+                 f'{latest_release_ver_finialized}({latest_release_ver}) > {local_ver_finialized}({local_ver})')
         return str(latest_release_ver), releases[latest_release_ver]
     else:
-        log.debug(f'No new version {latest_release_ver} <= {local_ver}')
+        log.debug(f'No new version '
+                  f'{latest_release_ver_finialized}({latest_release_ver}) <= {local_ver_finialized}({local_ver})')
         return None
 
 


### PR DESCRIPTION
Finalize versions before doing new release check, since we use prerelease/build in a released build version