### PR TITLE
Bugfix/js/24 windows path warning

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -78,7 +78,7 @@ jobs:
         rm -rv ./dist/logs
         rm -rv ./dist/OATFWGUI/__pycache__
     - name: Set artifact name
-      run: echo "ARTIFACT_ZIP_NAME=OATFWGUI_${{ env.OATFWGUI_VERSION }}_${{ runner.os }}_${{ runner.arch }}" >> $GITHUB_ENV
+      run: echo "ARTIFACT_ZIP_NAME=OATFWGUI_${{ env.OATFWGUI_VERSION }}_${{ runner.os }}" >> $GITHUB_ENV
     - name: Rename and Zip artifacts
       run: mv dist $ARTIFACT_ZIP_NAME && 7z a -tzip $ARTIFACT_ZIP_NAME.zip $ARTIFACT_ZIP_NAME/
       env:
@@ -131,7 +131,7 @@ jobs:
         rm -rv ./dist/.venv_*
         rm -rv ./dist/OATFWGUI/__pycache__
     - name: Set artifact name
-      run: echo "ARTIFACT_ZIP_NAME=OATFWGUI_${{ env.OATFWGUI_VERSION }}_${{ runner.os }}_${{ runner.arch }}" >> $GITHUB_ENV
+      run: echo "ARTIFACT_ZIP_NAME=OATFWGUI_${{ env.OATFWGUI_VERSION }}_${{ runner.os }}" >> $GITHUB_ENV
     - name: Rename and Zip artifacts
       run: mv dist $ARTIFACT_ZIP_NAME && 7z a -tzip $ARTIFACT_ZIP_NAME.zip $ARTIFACT_ZIP_NAME/
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 build_*/
 dist*/
 *__pycache__/
+OATFW/

--- a/OATFWGUI/external_processes.py
+++ b/OATFWGUI/external_processes.py
@@ -81,7 +81,7 @@ class ExternalProcess:
             QProcess.Running: 'Running',
         }.get(state)
         self.state = state
-        log.info(f'{self.proc_name}:State changed: {state_name}')
+        log.debug(f'{self.proc_name}:State changed: {state_name}')
 
 
 # Global dict to be modified after we can verify the external process exists

--- a/OATFWGUI/gui_logic.py
+++ b/OATFWGUI/gui_logic.py
@@ -3,6 +3,7 @@ import logging
 import sys
 import zipfile
 import json
+import shutil
 from typing import List, Optional
 from pathlib import Path
 
@@ -66,11 +67,19 @@ def extract_fw(zipfile_name: Path) -> Path:
     with zipfile.ZipFile(zipfile_name, 'r') as zip_ref:
         zip_infolist = zip_ref.infolist()
         if len(zip_infolist) > 0 and zip_infolist[0].is_dir():
-            fw_dir = Path(get_install_dir(), zip_infolist[0].filename)
+            extracted_dir = Path(get_install_dir(), zip_infolist[0].filename)
         else:
             log.fatal(f'Could not find FW top level directory in {zip_infolist}!')
             sys.exit(1)
         zip_ref.extractall()
+
+    # For Windows path length reasons, keep the downloaded firmware name short
+    fw_dir = Path(get_install_dir(), 'OATFW')
+    log.info(f'Rename {extracted_dir} to {fw_dir}')
+    if fw_dir.exists():
+        log.info(f'Removing previously downloaded FW from {fw_dir}')
+        shutil.rmtree(fw_dir, ignore_errors=True)
+    shutil.move(extracted_dir, fw_dir)
     log.info(f'Extracted FW to {fw_dir}')
     return fw_dir
 

--- a/OATFWGUI/log_utils.py
+++ b/OATFWGUI/log_utils.py
@@ -65,10 +65,13 @@ class CustomFormatter(logging.Formatter):
         return pre, post
 
     def _colour_html(self, levelno: int) -> Tuple[str, str]:
+        # https://coolors.co/contrast-checker/c9cd02-ffffff
+        # Light theme background: #FFFFFF
+        # Dark theme background: #1B1E20
         pre, post = {
             logging.DEBUG: ('<p style="color:SlateGray">', '</p>'),
             logging.INFO: ('<p style="color:grey">', '</p>'),
-            logging.WARNING: ('<p style="color:yellow">', '</p>'),
+            logging.WARNING: ('<p style="color:#C9CD02">', '</p>'),
             logging.ERROR: ('<p style="color:red">', '</p>'),
             logging.CRITICAL: ('<p style="color:red">', '</p>'),
         }.get(levelno, ('', ''))

--- a/OATFWGUI/main.py
+++ b/OATFWGUI/main.py
@@ -197,7 +197,7 @@ class MainWindow(QMainWindow):
 def main():
     setup_environment()
     log.debug('Creating app')
-    app = QApplication(sys.argv)
+    app = QApplication()
 
     log.debug('Creating main window')
     widget = MainWindow()

--- a/OATFWGUI/main.py
+++ b/OATFWGUI/main.py
@@ -222,4 +222,5 @@ if __name__ == '__main__':
     log = logging.getLogger('')
     l_o = LogObject()
     setup_logging(log, l_o)
+    log.debug('Set up logging')
     main()

--- a/OATFWGUI/main.py
+++ b/OATFWGUI/main.py
@@ -48,11 +48,11 @@ def setup_environment():
     log.debug(f'Install dir is {install_dir}')
     if get_platform() == PlatformEnum.WINDOWS:
         # With 54fa285a dependencies the maximum path length is 180.
-        # 260-180=80, but derate to 75 (for possible future increases)
+        # 260-152=108, but derate to 100 (for possible future increases)
         # pushd {install_dir} && find . -print|awk '{print length($0), $0}'|sort --numeric --reverse|head -n20
         log_msg = f'''If you get 'file not found' errors the easiest solution is to move
 the {install_dir.resolve()} folder somewhere with less characters in the path.'''
-        check_and_warn_directory_path_length(install_dir, 75, log_msg)
+        check_and_warn_directory_path_length(install_dir, 100, log_msg)
 
     # Putting the platformio core directory in a temporary folder is only needed because
     # Windows doesn't support long path names... :/

--- a/OATFWGUI/main.py
+++ b/OATFWGUI/main.py
@@ -56,7 +56,7 @@ the {install_dir.resolve()} folder somewhere with less characters in the path.''
 
     # Putting the platformio core directory in a temporary folder is only needed because
     # Windows doesn't support long path names... :/
-    pio_core_dir = Path(tempfile.gettempdir(), f'.pio_OATFWGUI_{__version__}')
+    pio_core_dir = Path(tempfile.gettempdir(), f'.pioOATFWGUI{__version__}')
     log.info(f'Setting PLATFORMIO_CORE_DIR to {pio_core_dir}')
     os.environ['PLATFORMIO_CORE_DIR'] = str(pio_core_dir)
 

--- a/OATFWGUI/qt_extensions.py
+++ b/OATFWGUI/qt_extensions.py
@@ -5,7 +5,7 @@ import math
 import enum
 from typing import Optional, Tuple
 
-from PySide6.QtCore import Slot, Signal, QObject, QRunnable, Qt, QSize
+from PySide6.QtCore import Slot, Signal, QObject, QRunnable, Qt, QSize, QMetaMethod
 from PySide6.QtWidgets import QWidget, QStackedWidget, QHBoxLayout, QSizePolicy
 from PySide6.QtGui import QPainter, QColor, QPen
 
@@ -151,3 +151,16 @@ class QIndicatorBad(QWidget):
                          on_circle_bot_half * bounding_size, on_circle_bot_half * bounding_size)
         painter.drawLine(on_circle_top_half * bounding_size, on_circle_bot_half * bounding_size,
                          on_circle_bot_half * bounding_size, on_circle_top_half * bounding_size)
+
+
+# https://stackoverflow.com/a/68621792/1313872
+# Idk why this is so hard for Qt
+def get_signal(o_object: QObject, str_signal_name: str) -> Optional[QMetaMethod]:
+    o_meta_obj = o_object.metaObject()
+    for i in range(o_meta_obj.methodCount()):
+        o_meta_method = o_meta_obj.method(i)
+        if not o_meta_method.isValid():
+            continue
+        if o_meta_method.methodType() == QMetaMethod.Signal and o_meta_method.name() == str_signal_name:
+            return o_meta_method
+    return None


### PR DESCRIPTION
Changes:
- Make warning yellow colour easier to see on white background
- Buffer log messages until graphics interface has started (previously early log messages were lost)
- Reduce path lengths where possible
  - Remove underscores in `pio_core_dir`
  - Remove arch (`_X64`) from CI build version
  - Change downloaded FW from a real name to constant `OATFW`
- Check and warning for long path names

Fixes #24 