### PR TITLE
Add warnings banner, redirect Qt messages

### DIFF
--- a/OATFWGUI/log_utils.py
+++ b/OATFWGUI/log_utils.py
@@ -13,6 +13,7 @@ from PySide6.QtCore import Slot, Signal, QObject, QFileSystemWatcher, QFile, QMe
 from external_processes import get_install_dir
 from platform_check import get_platform, PlatformEnum
 from qt_extensions import get_signal
+from qwarningbannerholder import global_warning_banners
 
 
 class LogObject(QObject):
@@ -110,6 +111,7 @@ class LoggedExternalFile:
         watch_success = self.file_watcher.addPath(self.tempfile.name)
         if not watch_success:
             self.log.warning(f'Could not watch external file: {self.tempfile.name}')
+            global_warning_banners.add(f'Could not watch external file: {self.tempfile.name}')
             return None
         return self.tempfile.name
 

--- a/OATFWGUI/main.py
+++ b/OATFWGUI/main.py
@@ -24,6 +24,7 @@ from log_utils import LogObject, setup_logging
 from gui_logic import BusinessLogic
 from platform_check import get_platform, PlatformEnum
 from external_processes import external_processes, add_external_process, get_install_dir
+from qwarningbannerholder import global_warning_banners
 from anon_usage_data import create_anon_stats
 from misc_utils import delete_directory
 
@@ -43,6 +44,7 @@ have too many characters in it ({num_chars_in_dir})! Downloading/building firmwa
 lengths greater than the default Windows path length of 260 characters.
 '''
         log.warning(general_warn_str + warn_str)
+        global_warning_banners.add(f'{dir_to_check} might have too many characters in it ({num_chars_in_dir})!')
 
 
 def setup_environment():
@@ -107,6 +109,7 @@ def raw_version_to_semver() -> Optional[semver.VersionInfo]:
         semver_ver = semver.VersionInfo.parse(__version__)
     except ValueError as e:
         log.warning(f'Could not parse my own version string {__version__} {e}')
+        global_warning_banners.add(f'Could not parse my own version string {__version__}')
         return None
     return semver_ver
 
@@ -130,6 +133,7 @@ def check_new_oatfwgui_release() -> Optional[Tuple[str, str]]:
             release_ver = semver.VersionInfo.parse(release_json['tag_name'])
         except ValueError as e:
             log.warning(f'Could not parse tag name as semver {release_json["tag_name"]} {e}')
+            global_warning_banners.add(f'Could not parse tag name as semver {release_json["tag_name"]}')
             continue
         releases[release_ver] = release_json['html_url']
         if latest_release_ver is None or release_ver > latest_release_ver:

--- a/OATFWGUI/main_widget.ui
+++ b/OATFWGUI/main_widget.ui
@@ -175,7 +175,6 @@
    <class>QBusyIndicatorGoodBad</class>
    <extends>QWidget</extends>
    <header>qbusyindicatorgoodbad</header>
-   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/OATFWGUI/main_widget.ui
+++ b/OATFWGUI/main_widget.ui
@@ -24,17 +24,16 @@
      </property>
      <item>
       <layout class="QGridLayout" name="gridLayout">
+       <item row="3" column="4">
+        <widget class="QBusyIndicatorGoodBad" name="wSpn_upload"/>
+       </item>
+       <item row="2" column="4">
+        <widget class="QBusyIndicatorGoodBad" name="wSpn_build"/>
+       </item>
        <item row="1" column="3">
         <widget class="QPushButton" name="wBtn_select_local_config">
          <property name="text">
           <string>Select local config file</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="3">
-        <widget class="QPushButton" name="wBtn_what_stats">
-         <property name="text">
-          <string>What will be uploaded?</string>
          </property>
         </widget>
        </item>
@@ -48,34 +47,17 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
-        <widget class="QComboBox" name="wCombo_serial_port">
-         <property name="placeholderText">
-          <string>No port selected</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QComboBox" name="wCombo_pio_env">
-         <property name="placeholderText">
-          <string>No FW downloaded yet...</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="wMsg_fw_version">
+       <item row="1" column="0">
+        <widget class="QLabel" name="wMsg_pio_env">
          <property name="text">
-          <string>Select firmware version:</string>
+          <string>Select board:</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="3">
-        <widget class="QPushButton" name="wBtn_download_fw">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
+       <item row="5" column="3">
+        <widget class="QPushButton" name="wBtn_what_stats">
          <property name="text">
-          <string>Download</string>
+          <string>What will be uploaded?</string>
          </property>
         </widget>
        </item>
@@ -89,17 +71,37 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="wMsg_pio_env">
+       <item row="0" column="0">
+        <widget class="QLabel" name="wMsg_fw_version">
          <property name="text">
-          <string>Select board:</string>
+          <string>Select firmware version:</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="wCombo_fw_version">
+       <item row="0" column="4">
+        <widget class="QBusyIndicatorGoodBad" name="wSpn_download"/>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="wCombo_pio_env">
          <property name="placeholderText">
-          <string>Grabbing FW Versions...</string>
+          <string>No FW downloaded yet...</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="4">
+        <widget class="QLabel" name="wMsg_config_path">
+         <property name="text">
+          <string>No config file selected</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="3">
+        <widget class="QPushButton" name="wBtn_download_fw">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Download</string>
          </property>
         </widget>
        </item>
@@ -116,8 +118,12 @@
          </property>
         </spacer>
        </item>
-       <item row="2" column="4">
-        <widget class="QBusyIndicatorGoodBad" name="wSpn_build"/>
+       <item row="3" column="1">
+        <widget class="QComboBox" name="wCombo_serial_port">
+         <property name="placeholderText">
+          <string>No port selected</string>
+         </property>
+        </widget>
        </item>
        <item row="1" column="4">
         <widget class="QPushButton" name="wBtn_build_fw">
@@ -136,18 +142,15 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="4">
-        <widget class="QBusyIndicatorGoodBad" name="wSpn_upload"/>
-       </item>
-       <item row="0" column="4">
-        <widget class="QBusyIndicatorGoodBad" name="wSpn_download"/>
-       </item>
-       <item row="2" column="0" colspan="4">
-        <widget class="QLabel" name="wMsg_config_path">
-         <property name="text">
-          <string>No config file selected</string>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="wCombo_fw_version">
+         <property name="placeholderText">
+          <string>Grabbing FW Versions...</string>
          </property>
         </widget>
+       </item>
+       <item row="7" column="0" colspan="5">
+        <widget class="QWarningBannerHolder" name="wWarnBanner"/>
        </item>
       </layout>
      </item>
@@ -175,6 +178,11 @@
    <class>QBusyIndicatorGoodBad</class>
    <extends>QWidget</extends>
    <header>qbusyindicatorgoodbad</header>
+  </customwidget>
+  <customwidget>
+   <class>QWarningBannerHolder</class>
+   <extends>QWidget</extends>
+   <header>qwarningbannerholder</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/OATFWGUI/platform_check.py
+++ b/OATFWGUI/platform_check.py
@@ -2,6 +2,8 @@ import enum
 import platform
 import logging
 
+from qwarningbannerholder import global_warning_banners
+
 platform_lookup_cache = None
 log = logging.getLogger('')
 
@@ -33,5 +35,6 @@ def get_platform() -> PlatformEnum:
     log.debug(f'platform_str={platform_str}')
     if platform_lookup == PlatformEnum.UNKNOWN:
         log.warning(f'Unknown platform {platform_str}!')
+        global_warning_banners.add(f'Unknown platform {platform_str}!')
 
     return platform_lookup

--- a/OATFWGUI/qbusyindicatorgoodbad.py
+++ b/OATFWGUI/qbusyindicatorgoodbad.py
@@ -13,31 +13,6 @@ log = logging.getLogger('')
 
 
 class BusyIndicatorState(enum.Enum):
-    # designer_dom_xml = '''
-    # <ui language='c++'>
-    #     <widget class='QBusyIndicatorGoodBad' name='qBusyIndicatorGoodBad'>
-    #         <property name='fixed_size'>
-    #             <size>
-    #                 <width>10</width>
-    #                 <height>10</height>
-    #             </size>
-    #         </property>
-    #     </widget>
-    # </ui>
-    # '''
-    #
-    # def get_fixed_size(self) -> QSize:
-    #     return self._fixed_size
-    #
-    # def set_fixed_size(self, fixed_size: QSize):
-    #     self._fixed_size = fixed_size
-    #     self.setFixedSize(fixed_size)
-    #
-    # fixed_size = Property(QSize, get_fixed_size, set_fixed_size)
-    #
-    # ...
-    #
-    # self._fixed_size = QSize(200, 200)
     NONE = enum.auto()
     BUSY = enum.auto()
     GOOD = enum.auto()

--- a/OATFWGUI/qt_extensions.py
+++ b/OATFWGUI/qt_extensions.py
@@ -55,7 +55,7 @@ class RegisteredCustomWidget(QWidget):
     def factory(cls: 'RegisteredCustomWidget'):
         if not cls.designer_tooltip:
             cls.designer_tooltip = f'{cls.__name__} tooltip'
-        if cls.designer_dom_xml:
+        if not cls.designer_dom_xml:
             cls.designer_dom_xml = f'''
 <ui language='c++'>
     <widget class='{cls.__name__}' name='{cls.__name__.lower()}'>

--- a/OATFWGUI/qwarningbannerholder.py
+++ b/OATFWGUI/qwarningbannerholder.py
@@ -1,0 +1,38 @@
+from typing import List
+
+from PySide6.QtCore import Slot, Signal, Qt
+from PySide6.QtWidgets import QVBoxLayout, QSizePolicy, QLabel
+from qt_extensions import RegisteredCustomWidget
+
+
+class QWarningBannerHolder(RegisteredCustomWidget):
+    add_warning_signal = Signal(str)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.label_widgets: List[QWarningLabel] = []
+
+        self.vbox = QVBoxLayout()
+        self.vbox.setAlignment(Qt.AlignHCenter)
+        self.setLayout(self.vbox)
+        self.add_warning_signal.connect(self.add_warning)
+
+        if self.running_in_designer():
+            self.add_warning_signal.emit('Test warning 1')
+            self.add_warning_signal.emit('Test warning 2')
+            self.add_warning_signal.emit('Test warning 3')
+
+    # Need to use signals and slots else we get:
+    # QObject::setParent: Cannot set parent, new parent is in a different thread
+    @Slot()
+    def add_warning(self, text: str):
+        self.label_widgets.append(QWarningLabel(text))
+        self.vbox.addWidget(self.label_widgets[-1])
+
+
+class QWarningLabel(QLabel):
+    def __init__(self, text: str):
+        super().__init__(f'WARNING:{text}')
+        self.setStyleSheet('QLabel { background-color : yellow; }')
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)

--- a/OATFWGUI/qwarningbannerholder.py
+++ b/OATFWGUI/qwarningbannerholder.py
@@ -1,8 +1,10 @@
-from typing import List
+from typing import List, Set
 
-from PySide6.QtCore import Slot, Signal, Qt
+from PySide6.QtCore import Slot, Signal, Qt, QTimer
 from PySide6.QtWidgets import QVBoxLayout, QSizePolicy, QLabel
 from qt_extensions import RegisteredCustomWidget
+
+global_warning_banners: Set[str] = set()
 
 
 class QWarningBannerHolder(RegisteredCustomWidget):
@@ -16,12 +18,25 @@ class QWarningBannerHolder(RegisteredCustomWidget):
         self.vbox = QVBoxLayout()
         self.vbox.setAlignment(Qt.AlignHCenter)
         self.setLayout(self.vbox)
+
+        self.check_timer = QTimer(self)
+        self.check_timer.timeout.connect(self.check_global_warnings)
+        self.check_timer.setInterval(1000)  # every second
+        self.check_timer.start()
+
         self.add_warning_signal.connect(self.add_warning)
 
         if self.running_in_designer():
-            self.add_warning_signal.emit('Test warning 1')
-            self.add_warning_signal.emit('Test warning 2')
-            self.add_warning_signal.emit('Test warning 3')
+            global_warning_banners.add('Test warning 1')
+            global_warning_banners.add('Test warning 2')
+            global_warning_banners.add('Test warning 3')
+
+    def check_global_warnings(self):
+        # Just go through all of our labels and compare the text
+        # Not efficient but whatever
+        for warn_str in global_warning_banners:
+            if not any(warn_str in wid.text() for wid in self.label_widgets):
+                self.add_warning_signal.emit(warn_str)
 
     # Need to use signals and slots else we get:
     # QObject::setParent: Cannot set parent, new parent is in a different thread

--- a/OATFWGUI/register_custom_qt_widgets.py
+++ b/OATFWGUI/register_custom_qt_widgets.py
@@ -1,6 +1,7 @@
 from PySide6.QtDesigner import QPyDesignerCustomWidgetCollection
 
 from qbusyindicatorgoodbad import QBusyIndicatorGoodBad
+from qwarningbannerholder import QWarningBannerHolder
 
 """
 Set the environment variable PYSIDE_DESIGNER_PLUGINS to this directory and load the plugin,
@@ -16,4 +17,11 @@ if __name__ == '__main__':
         module=qbusyindicatorgoodbad.designer_module,  # idk what this actually affects
         tool_tip=qbusyindicatorgoodbad.designer_tooltip,
         xml=qbusyindicatorgoodbad.designer_dom_xml,
+    )
+    qwarningbannerholder = QWarningBannerHolder.factory()
+    QPyDesignerCustomWidgetCollection.registerCustomWidget(
+        qwarningbannerholder,
+        module=qwarningbannerholder.designer_module,  # idk what this actually affects
+        tool_tip=qwarningbannerholder.designer_tooltip,
+        xml=qwarningbannerholder.designer_dom_xml,
     )


### PR DESCRIPTION
- Add a warning banner widget for common problems (instead of having to catch a warning log that may scroll off the screen)
- Redirect Qt messages to our logs
  - Previously they would just go to stderr, which isn't helpful