### PR TITLE
Update platformio version to fix broken scons `4.40400.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-platformio==6.1.4
+platformio==6.1.13
 PySide6-Essentials==6.5.3  # Last version that supports python 3.7
 requests~=2.28.1
 semver~=2.13.0


### PR DESCRIPTION
I guess either Platformio or SCons pulled their `4.40400.0` version (version 4.4) because recently builds have been failing (on both Windows and Linux) :
```
2024-03-18 17:20:25,419:INFO:Tool Manager: Installing platformio/tool-scons @ ~4.40400.0
2024-03-18 17:20:26,462:ERROR:Error: Could not find the package with 'platformio/tool-scons @ ~4.40400.0' requirements for your system 'linux_x86_64'
```
(The tool version is hardcoded and comes from: https://github.com/platformio/platformio-core/blob/v6.1.13/platformio/__init__.py#L44 )

Updating platformio changes the required SCons version to `4.40600.0` (version 4.6) and it now installs successfully. :upside_down_face: 