### PR TITLE
Drop 3.7, 3.8 support, enable 3.12, 3 .13 support for Linux

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -127,7 +127,7 @@ jobs:
     runs-on: 'ubuntu-20.04'
     strategy:
       matrix:
-        py_version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        py_version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -118,13 +118,13 @@ jobs:
       env:
         ARTIFACT_ZIP_NAME: ${{ env.ARTIFACT_ZIP_NAME }}
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACT_ZIP_NAME }}
         path: ${{ env.ARTIFACT_ZIP_NAME }}.zip
 
   build-virtualenv:
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-22.04'
     strategy:
       matrix:
         py_version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
@@ -171,8 +171,8 @@ jobs:
       env:
         ARTIFACT_ZIP_NAME: ${{ env.ARTIFACT_ZIP_NAME }}
     - name: Upload artifact
-      if: ${{ matrix.py_version }} == "3.10" # Only publish one artifact
-      uses: actions/upload-artifact@v3
+      if: ${{ matrix.py_version == 3.10 }} # Only publish one artifact
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACT_ZIP_NAME }}
         path: ${{ env.ARTIFACT_ZIP_NAME }}.zip
@@ -181,14 +181,14 @@ jobs:
     # only publish release on tags
     if: ${{ startsWith(github.ref, 'refs/tags/') == true }}
     needs: [build-windows, build-virtualenv]
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-22.04'
     permissions:
       # See https://github.com/softprops/action-gh-release/issues/236#issuecomment-1150530128
       contents: write
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Show artifact contents

--- a/OATFWGUI/gui_logic.py
+++ b/OATFWGUI/gui_logic.py
@@ -120,7 +120,8 @@ class BusinessLogic:
     def spawn_worker_thread(self, fn):
         @Slot()
         def worker_thread_slot():
-            all_threads_removed = self.threadpool.waitForDone(msecs=5000)
+            msecs = 5000
+            all_threads_removed = self.threadpool.waitForDone(msecs)
             if not all_threads_removed:
                 log.fatal(f'Waited too long for threads to sys.exit! {self.threadpool.activeThreadCount()}')
                 sys.exit(1)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ OpenAstroTech FirmWare Graphical User Interface -- A graphical way to build and 
 ## Supported platforms
 - Windows 64 bit
 - Linux 64 bit
-  - Requires Python 3.7..3.11, git, libc >= 2.28 (check with `ldd --version`)
+  - Requires Python 3.9..3.13, git, libc >= 2.28 (check with `ldd --version`)
 
 MacOS support [is in progress](https://github.com/OpenAstroTech/OATFWGUI/commits/feature/js/official-mac-support/), but isn't reliable yet.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-platformio==6.1.13
-PySide6-Essentials==6.5.3  # Last version that supports python 3.7
-requests~=2.28.1
+platformio==6.1.16  # Hard-pin version so that issues can be reproduced
+PySide6-Essentials~=6.8.1
+requests~=2.32.3
 semver~=2.13.0
-pygments~=2.13.0
+pygments~=2.18.0

--- a/scripts/OATFWGUI_Linux.sh
+++ b/scripts/OATFWGUI_Linux.sh
@@ -2,7 +2,6 @@
 set -e
 # This is the entry point for the "compiled" Linux app
 
-# list_include_item "10 11 12" "2"
 function list_include_item {
   local list="$1"
   local item="$2"
@@ -32,6 +31,7 @@ function check_ldd_version {
     return 1
   fi
   # Only support >= 28
+  # 2.28 from: https://doc.qt.io/qt-6/supported-platforms.html#availability-of-packages
   if [ "$LIBC_VER_MIN" -lt 28 ]; then
     echo "LIBC minor version $LIBC_VER_MIN ($LIBC_VER_ALL) is not supported"
     return 1
@@ -58,7 +58,7 @@ function check_py_version {
     return 1
   fi
   # Only support 3.7+
-  if ! list_include_item '7 8 9 10 11' "$PY_VER_MIN"; then
+  if ! list_include_item '9 10 11 12 13' "$PY_VER_MIN"; then
     echo "Python minor version $PY_VER_MIN ($PY_VER_ALL) is not supported"
     return 1
   fi


### PR DESCRIPTION
PySide update dropped the `msecs` named parameter from `QThreadPool::waitForDone` for some reason, isn't really clear in the docs.