### PR TITLE
Don't `setCurrentIndex` on serial port combo

### DIFF
--- a/OATFWGUI/gui_logic.py
+++ b/OATFWGUI/gui_logic.py
@@ -361,11 +361,6 @@ class BusinessLogic:
         self.main_app.wCombo_serial_port.clear()
         for serial_port in self.logic_state.serial_ports:
             self.main_app.wCombo_serial_port.addItem(serial_port)
-        if len(self.logic_state.serial_ports) > 0:
-            self.main_app.wCombo_serial_port.setCurrentIndex(0)
-        else:
-            self.logic_state.upload_port = None
-            self.main_app.wCombo_serial_port.setCurrentIndex(-1)
 
     @Slot()
     def serial_port_combo_box_changed(self, idx: int):


### PR DESCRIPTION
Something got weird and then broke (PySide6-Essentials 6.6.1, 6.6.3) with `QComboBox` and trying to use the `setCurrentIndex` slot in another thread gives

```
QBasicTimer::start: Timers cannot be started from another thread
QObject::startTimer: Timers cannot be started from another thread
```

errors when selecting the combo box afterwards. This was just a QoL feature so just remove it.